### PR TITLE
fix script shebang

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # global for error reporting
 ASDF_MAVEN_ERROR=""


### PR DESCRIPTION
/bin/env is missing on some systems, use /usr/bin/env